### PR TITLE
Add CivitAI Link Button plugin

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -695,4 +695,16 @@
         "minEDVersion": "2.0",
         "compatIssueIds": []
     }
+    {
+        "id": "civitai-link-button",
+        "icon": "fa-link",
+        "name": "CivitAI Link Button",
+        "author": "Pavel Vanecek",
+        "description": "Adds a CivitAI search button under the model selector in EasyDiffusion. Opens the correct CivitAI.red search URL for the selected model.",
+        "url": "https://raw.githubusercontent.com/pavelvanecekcz/EasyDiffusion-plugin-CivitAi/main/civitai-link.plugin.js",
+        "localInstallOnly": false,
+        "version": "1.0.0",
+        "minEDVersion": "3.5",
+        "compatIssueIds": []        
+    }
 ]


### PR DESCRIPTION
Add CivitAI Link Button plugin

This plugin adds a CivitAI search button under the model selector in EasyDiffusion.
It opens the correct CivitAI.red search URL for the selected model.

Repository: https://github.com/pavelvanecekcz/EasyDiffusion-plugin-CivitAi [(github.com in Bing)](https://www.bing.com/search?q=%22https%3A%2F%2Fgithub.com%2Fpavelvanecekcz%2FEasyDiffusion-plugin-CivitAi%22)

Tested on EasyDiffusion 3.5.x.